### PR TITLE
Update microstates version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "ember-auto-import": "1.2.19",
     "ember-cli-babel": "^7.2.0",
-    "microstates": "0.12.3"
+    "microstates": "^0.12.4"
   },
   "devDependencies": {
     "@bigtest/interactor": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-auto-import": "1.2.19",
+    "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.2.0",
     "microstates": "^0.12.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,7 +4002,34 @@ ember-ast-helpers@0.3.5:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"
 
-ember-auto-import@1.2.19:
+ember-auto-import@^1.2.13:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.15.tgz#3da74f83704f4c095dc1affec25a68f396ed5728"
+  integrity sha512-L9eyO5b135BXdzNMexhoxkPETBUQCkwp3lp4O2uu+hVEDUe2Z9m+/X8TdTRcuavkeFbQk5bgoXAGPzv4yaPjIg==
+  dependencies:
+    babel-core "^6.26.3"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^0.5.7"
+    handlebars "^4.0.11"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.2"
+    webpack "^4.12.0"
+
+ember-auto-import@^1.2.19:
   version "1.2.19"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.19.tgz#69a2da0d2c16ab88989c51381c415214e85d1af3"
   integrity sha512-OT7I3zrIAv/rbbYJFZNqfJi/2HpAscjOWOaBPPUj8VkUnY26HlLO6mSzDIkoUOaTAEWiy2GzjenHGj6b9rivxw==
@@ -4030,33 +4057,6 @@ ember-auto-import@1.2.19:
     rimraf "^2.6.2"
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.3"
-    webpack "^4.12.0"
-
-ember-auto-import@^1.2.13:
-  version "1.2.15"
-  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.15.tgz#3da74f83704f4c095dc1affec25a68f396ed5728"
-  integrity sha512-L9eyO5b135BXdzNMexhoxkPETBUQCkwp3lp4O2uu+hVEDUe2Z9m+/X8TdTRcuavkeFbQk5bgoXAGPzv4yaPjIg==
-  dependencies:
-    babel-core "^6.26.3"
-    babel-plugin-syntax-dynamic-import "^6.18.0"
-    babel-template "^6.26.0"
-    babylon "^6.18.0"
-    broccoli-debug "^0.6.4"
-    broccoli-plugin "^1.3.0"
-    debug "^3.1.0"
-    ember-cli-babel "^6.6.0"
-    enhanced-resolve "^4.0.0"
-    fs-extra "^6.0.1"
-    fs-tree-diff "^0.5.7"
-    handlebars "^4.0.11"
-    js-string-escape "^1.0.1"
-    lodash "^4.17.10"
-    mkdirp "^0.5.1"
-    pkg-up "^2.0.0"
-    resolve "^1.7.1"
-    rimraf "^2.6.2"
-    symlink-or-copy "^1.2.0"
-    walk-sync "^0.3.2"
     webpack "^4.12.0"
 
 ember-burger-menu@3.3.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7872,10 +7872,10 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-microstates@0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/microstates/-/microstates-0.12.3.tgz#176def447c7625edf9b43c3cfc4bbcccd0e8be90"
-  integrity sha512-Rp69LbIrd1e+UjxqhUEt2MqTnTwfYavEwFnECVdJ2wNeEu/wZyLwvct9HJwsFRtvHB+80YCoqvTxdAYWobNwMQ==
+microstates@^0.12.4:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/microstates/-/microstates-0.12.4.tgz#c9dd7786670df60b4f62c11c59084004bc18a341"
+  integrity sha512-qLWSfYlL0PD8NtAIphI37tqF5o3DSzY57BHInXJtWL4/W/ZnWNkUlTp44hrXBVzuKC2rWjygbvsjMA2fIn9Oyw==
   dependencies:
     funcadelic "^0.5.0"
     symbol-observable "^1.2.0"


### PR DESCRIPTION
Previously, the `dependency` versions were quite strict. Now updated versions of the dependencies are allowed, which either ensures people get the latest version of `microstates` (rather than that specific one) or allows people to de-duplicate their version of `ember-auto-import` if other dependencies also have it installed.

Closes #99 