### PR TITLE
Dynamically pick which microstates dist to use

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -15,4 +15,4 @@ export {
   reduce,
   map,
   filter
-} from "microstates/dist/microstates.cjs";
+} from "microstates";

--- a/index.js
+++ b/index.js
@@ -1,5 +1,31 @@
 'use strict';
 
+/*
+  We need to dynamically pick which build of microstates to use based on if 
+  the consuming app uses non-evergreen browsers or not. This is because 
+  native es6 classes and transpiled classes don't work together.
+*/
+function chooseMicrostatesDistribution(targets) {
+  if (targets && targets.browsers && targets.browsers.includes('ie 11')) {
+    return 'microstates/dist/microstates.es.js'
+  }
+
+  return 'microstates/dist/microstates.umd.js'
+}
+
 module.exports = {
-  name: require('./package').name
-};
+  name: require('./package').name,
+
+  options: {
+    autoImport: {
+      alias: {}
+    }
+  },
+
+  included() {
+    // Dynamically pick which distribution of microstates to use before ember-auto-import does it's magic
+    // We need to this here so we can access `this.project`
+    this.options.autoImport.alias.microstates = chooseMicrostatesDistribution(this.project.targets);
+    this._super.included.apply(this, arguments);
+  },
+}

--- a/tests/integration/helpers/type-test.js
+++ b/tests/integration/helpers/type-test.js
@@ -13,7 +13,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "any") (import "microstates/dist/microstates.cjs?Any")) "true" "false"}}`
+      hbs`{{if (eq (type "any") (import "microstates?Any")) "true" "false"}}`
     );
 
     expect(
@@ -27,7 +27,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "boolean") (import "microstates/dist/microstates.cjs?BooleanType")) "true" "false"}}`
+      hbs`{{if (eq (type "boolean") (import "microstates?BooleanType")) "true" "false"}}`
     );
 
     expect(
@@ -41,7 +41,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "string") (import "microstates/dist/microstates.cjs?StringType")) "true" "false"}}`
+      hbs`{{if (eq (type "string") (import "microstates?StringType")) "true" "false"}}`
     );
 
     expect(
@@ -55,7 +55,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "number") (import "microstates/dist/microstates.cjs?NumberType")) "true" "false"}}`
+      hbs`{{if (eq (type "number") (import "microstates?NumberType")) "true" "false"}}`
     );
 
     expect(
@@ -69,7 +69,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "array") (import "microstates/dist/microstates.cjs?ArrayType")) "true" "false"}}`
+      hbs`{{if (eq (type "array") (import "microstates?ArrayType")) "true" "false"}}`
     );
 
     expect(
@@ -83,7 +83,7 @@ describe("Integration | Helper | type", function() {
     initialize(this);
 
     this.render(
-      hbs`{{if (eq (type "object") (import "microstates/dist/microstates.cjs?ObjectType")) "true" "false"}}`
+      hbs`{{if (eq (type "object") (import "microstates?ObjectType")) "true" "false"}}`
     );
 
     expect(


### PR DESCRIPTION
Fix for #115 

We need to dynamically decide which version of microstates to use at build time based on the consuming app's browser targets. This is to make sure we don't have transpiled classes and native classes mixed together.