### PR TITLE
Changed TravisCI to use Yarn instead of NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 ---
 language: node_js
 node_js:
-  # we recommend testing addons with the same minimum supported node version as Ember CLI
-  # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -12,42 +10,21 @@ addons:
   chrome: stable
 
 cache:
-  directories:
-    - $HOME/.npm
+  yarn: true
 
 env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
-jobs:
-  fail_fast: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
-  include:
-    # runs linting and tests with current locked deps
-
-    - stage: "Tests"
-      name: "Tests"
-      script:
-        - npm run lint:js
-        - npm test
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-    # env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    # - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
 before_install:
-  - npm config set spin false
-  - npm install -g npm@4
-  - npm --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+install:
+  - yarn install --non-interactive
 
 script:
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+  - yarn lint:hbs
+  - yarn lint:js
+  - yarn test


### PR DESCRIPTION
# Motivation

TravisCI builds are failing in #163 possibly because dependencies are not being installed correctly.

# Approach

Change TravisCI to use yarn by copy and pasting the template from [ember-cli blueprints](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/.travis.yml) 