### PR TITLE
Adding automated NPM publishing

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,19 @@
+name: Publish Preview
+
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  preview: 
+    name: Publish Preview Package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: NPM Publish Preview
+      uses: thefrontside/actions/publish-pr-preview@v1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -7,13 +7,13 @@ on:
       - release-*
 
 jobs:
-  preview: 
+  preview:
     name: Publish Preview Package
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: NPM Publish Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.1
+      uses: thefrontside/actions/publish-pr-preview@v1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -16,4 +16,4 @@ jobs:
       uses: thefrontside/actions/publish-pr-preview@v1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Tag and Publish
-      uses: thefrontside/actions/synchronize-with-npm@v1.1
+      uses: thefrontside/actions/synchronize-with-npm@v1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,19 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  publish:
+    name: Synchronize with NPM
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Tag and Publish
+      uses: thefrontside/actions/synchronize-with-npm@v1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -1,0 +1,14 @@
+name: Synchronize NPM Tags
+
+on:
+  delete
+
+jobs:
+  clean:
+    name: Synchronize NPM Tags
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: thefrontside/actions/synchronize-npm-tags@v1.1
+      env:
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: thefrontside/actions/synchronize-npm-tags@v1.1
+    - uses: thefrontside/actions/synchronize-npm-tags@v1.2
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Motivation

We want to eliminate as much as possible any friction in consuming packages published from our repositories. This is important because when you find a bug or make an improvement, nothing feels worse than waiting for the package to be release. It also creates unnecessary dependency on the maintainers to manually publish.

## Approach

I'm adding GitHub Actions that Frontside developing that we can call Transparent NPM Publishing workflow. We'll eventually write a long blog post explaining how it works, but in the mean time we can enjoy the benefits of publishing without running `npm publish`.

There are 3 actions in play here,

1. [publish-pr-preview](https://github.com/thefrontside/actions/tree/master/publish-pr-preview) - automatically publish packages from pull request
2. [syncronize-with-npm](https://github.com/thefrontside/actions/tree/master/synchronize-with-npm) which runs on master and branches starting with `release-` to publish to npm whenever version in master changed
3. [synchronize-npm-tags](https://github.com/thefrontside/actions/tree/master/synchronize-npm-tags) - *I need to figure out what this does*

The workflows are as follows,

### When you want to consume changes from a PR

1. Create a pull request
2. You'll get a comment with information about package that was published

### When you want to release

1. Create a pull request with change to version in package.json
2. Once you merge, it'll automatically publish